### PR TITLE
Firefox friendly native

### DIFF
--- a/client/src/puzzles.js
+++ b/client/src/puzzles.js
@@ -92,7 +92,7 @@ export const puzzles = [
   },
   {
     name: 'native',
-    source: `const toString = Function.prototype.toString;\nfunction native(x) {\n    return (x() === 1) && (x.toString() === 'function () { [native code] }') && (toString.call(x) === x.toString())\n}`
+    source: `const toString = Function.prototype.toString;\nfunction native(x) {\n    return (x() === 1) && (x.toString().match(/function \\w* *\\(\\) {[ \\n]+\\[native code\\][ \\n]+}/)) && (toString.call(x) === x.toString())\n}`
   },
   {
     name: 'stringable',

--- a/client/src/puzzles.js
+++ b/client/src/puzzles.js
@@ -92,7 +92,7 @@ export const puzzles = [
   },
   {
     name: 'native',
-    source: `const toString = Function.prototype.toString;\nfunction native(x) {\n    return (x() === 1) && (x.toString().match(/function \\w* *\\(\\) {[ \\n]+\\[native code\\][ \\n]+}/)) && (toString.call(x) === x.toString())\n}`
+    source: `const toString = Function.prototype.toString;\nfunction native(x) {\n    return (x() === 1) &&\n        (x.toString().match(/function \\w* *\\(\\) {[ \\n]+\\[native code\\][ \\n]+}/)) &&\n        (toString.call(x) === x.toString())\n}`
   },
   {
     name: 'stringable',


### PR DESCRIPTION
This puzzle is impossible in Firefox because it requires the Google Chrome style string for `Function.protoype.toString()` of native functions. This should allow Firefox as well without adding any exploits.